### PR TITLE
Improve hierarchy navigation and graph aesthetics

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -33,13 +33,14 @@
     <main class="layout">
       <section class="sidebar" id="sidebar">
         <div class="panel">
-          <h2>Levels &amp; Scopes</h2>
+          <h2>Hierarchy explorer</h2>
           <p class="panel-help">
-            Use the collapsible sections below to reveal tasks by level and scope.
-            Checking a task adds it to the network view. Hidden tasks are treated as
-            collapsed milestones.
+            Begin with the Level 2 milestones. Selecting a card reveals the dependent
+            work in the next level, letting you trace the critical path step by step.
           </p>
+          <div class="panel-subhead">Current path</div>
           <div id="level-controls" class="level-controls"></div>
+          <div class="panel-subhead">Available tasks</div>
           <div id="hierarchy" class="hierarchy"></div>
         </div>
 

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -131,84 +131,142 @@ button:active,
   color: rgba(15, 23, 42, 0.7);
 }
 
+.panel-subhead {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.45);
+  margin-bottom: 0.65rem;
+}
+
+.panel-subhead:not(:first-of-type) {
+  margin-top: 1.25rem;
+}
+
+.panel-subhead + .level-controls,
+.panel-subhead + .hierarchy {
+  margin-top: -0.2rem;
+}
+
 .level-controls {
+  min-height: 48px;
+  margin-bottom: 1.5rem;
+}
+
+.selection-path {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem;
-  margin-bottom: 1.2rem;
+  gap: 0.5rem;
 }
 
-.level-pill {
-  padding: 0.35rem 0.8rem;
-  border-radius: 999px;
-  background: rgba(15, 23, 42, 0.06);
-  border: 1px solid transparent;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  font-size: 0.85rem;
+.path-chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-}
-
-.level-pill input {
-  margin: 0;
-}
-
-.level-pill.active {
-  border-color: var(--accent);
-  background: var(--accent-soft);
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  border: none;
+  background: rgba(37, 99, 235, 0.12);
   color: var(--accent);
-}
-
-.hierarchy details {
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  border-radius: 0.9rem;
-  padding: 0.75rem 1rem;
-  margin-bottom: 0.6rem;
-  background: rgba(148, 163, 184, 0.08);
-}
-
-.hierarchy summary {
-  cursor: pointer;
+  font-size: 0.8rem;
   font-weight: 600;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: none;
 }
 
-.scope-header {
+.path-chip span {
+  font-size: 0.75rem;
+  font-weight: 700;
+  opacity: 0.7;
+}
+
+.path-chip:hover {
+  background: rgba(37, 99, 235, 0.2);
+  transform: translateY(-1px);
+}
+
+.hierarchy {
+  display: grid;
+  gap: 1rem;
+}
+
+.hierarchy-column {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 1rem;
+  padding: 1rem 1.1rem;
+  background: rgba(148, 163, 184, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.hierarchy-column header h3 {
+  margin: 0;
   font-size: 0.95rem;
 }
 
-.task-list {
-  margin-top: 0.75rem;
+.hierarchy-column header p {
+  margin: 0.2rem 0 0;
+  font-size: 0.78rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.hierarchy-task-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  gap: 0.65rem;
+}
+
+.hierarchy-card {
+  border: none;
+  border-radius: 0.9rem;
+  padding: 0.75rem 0.85rem;
+  background: white;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+  text-align: left;
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  color: var(--text);
 }
 
-.task-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.45rem 0.65rem;
-  border-radius: 0.75rem;
-  background: white;
-  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
+.hierarchy-card .title {
+  font-size: 0.9rem;
+  font-weight: 600;
 }
 
-.task-item label {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  font-size: 0.88rem;
-}
-
-.task-item .info {
+.hierarchy-card .meta {
   font-size: 0.75rem;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.hierarchy-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(37, 99, 235, 0.18);
+}
+
+.hierarchy-card.selected {
+  outline: 2px solid var(--accent);
+  box-shadow: 0 18px 36px rgba(37, 99, 235, 0.24);
+  background: linear-gradient(135deg, rgba(219, 234, 254, 0.7), rgba(191, 219, 254, 0.8));
+}
+
+.empty-state {
+  font-size: 0.85rem;
   color: rgba(15, 23, 42, 0.6);
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.empty-state.soft {
+  background: rgba(255, 255, 255, 0.55);
 }
 
 .task-details {
@@ -277,8 +335,9 @@ button:active,
 .graph {
   height: 540px;
   border-radius: 1.5rem;
-  background: rgba(15, 23, 42, 0.9);
-  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
+  background: radial-gradient(circle at 25% 25%, rgba(241, 245, 249, 0.9), rgba(226, 232, 240, 0.85) 45%, rgba(148, 163, 184, 0.4));
+  box-shadow: 0 28px 70px rgba(15, 23, 42, 0.3);
+  border: 1px solid rgba(148, 163, 184, 0.35);
 }
 
 .graph-controls {


### PR DESCRIPTION
## Summary
- replace the level checkbox explorer with a hierarchy-driven card layout that reveals downstream levels as the user selects milestones
- refresh the sidebar copy and styling to highlight the active path and available tasks
- refine Cytoscape node styling with wrapped labels, softer visuals, and a clearer background treatment

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d0997cad908325806b45e7a338774a