### PR TITLE
Add cross-level hierarchy options and focused neighbor graph

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -36,7 +36,8 @@
           <h2>Hierarchy explorer</h2>
           <p class="panel-help">
             Begin with the Level 2 milestones. Selecting a card reveals the dependent
-            work in the next level, letting you trace the critical path step by step.
+            work in the next level, and any cross-level links surface alongside so you can
+            jump to related work even when it skips levels.
           </p>
           <div class="panel-subhead">Current path</div>
           <div id="level-controls" class="level-controls"></div>

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -220,6 +220,38 @@ button:active,
   gap: 0.65rem;
 }
 
+.hierarchy-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.hierarchy-group + .hierarchy-group {
+  padding-top: 0.75rem;
+  margin-top: 0.5rem;
+  border-top: 1px dashed rgba(37, 99, 235, 0.2);
+}
+
+.hierarchy-group.related {
+  background: rgba(191, 219, 254, 0.35);
+  border-radius: 0.85rem;
+  padding: 0.75rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+
+.hierarchy-group.related .hierarchy-task-list {
+  margin-top: 0.35rem;
+}
+
+.hierarchy-group-title {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(37, 99, 235, 0.65);
+}
+
 .hierarchy-card {
   border: none;
   border-radius: 0.9rem;
@@ -250,10 +282,32 @@ button:active,
   box-shadow: 0 16px 30px rgba(37, 99, 235, 0.18);
 }
 
+.hierarchy-card.related {
+  border: 1px dashed rgba(37, 99, 235, 0.4);
+  background: rgba(191, 219, 254, 0.5);
+  box-shadow: 0 14px 28px rgba(37, 99, 235, 0.18);
+}
+
 .hierarchy-card.selected {
   outline: 2px solid var(--accent);
   box-shadow: 0 18px 36px rgba(37, 99, 235, 0.24);
   background: linear-gradient(135deg, rgba(219, 234, 254, 0.7), rgba(191, 219, 254, 0.8));
+}
+
+.relationship-badge {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  margin-top: 0.25rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: rgba(37, 99, 235, 0.18);
+  color: var(--accent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 .empty-state {


### PR DESCRIPTION
## Summary
- surface cross-level dependencies in the hierarchy explorer so users can pick non-sequential tasks
- limit the network view to one-hop neighbors while highlighting contextual nodes
- refresh sidebar styling and copy to explain the new cross-level exploration behaviour

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68d09f88ad0083259f66f9f88aff9e0d