### PR TITLE
Highlight task and dependency cards from graph focus

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -35,9 +35,9 @@
         <div class="panel">
           <h2>Hierarchy explorer</h2>
           <p class="panel-help">
-            Begin with the Level 2 milestones. Selecting a card reveals the dependent
-            work in the next level, and any cross-level links surface alongside so you can
-            jump to related work even when it skips levels.
+            Start with the Level 2 milestones. Once you choose a card, the immediate Level 3
+            work appears here and in the network. Continue drilling down by selecting nodes in
+            the visualization to reveal their direct predecessors and successors.
           </p>
           <div class="panel-subhead">Current path</div>
           <div id="level-controls" class="level-controls"></div>

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -294,6 +294,15 @@ button:active,
   background: linear-gradient(135deg, rgba(219, 234, 254, 0.7), rgba(191, 219, 254, 0.8));
 }
 
+.hierarchy-card.network-selected {
+  border: 1px solid rgba(37, 99, 235, 0.35);
+  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.18);
+}
+
+.hierarchy-card.selected.network-selected {
+  outline-width: 3px;
+}
+
 .relationship-badge {
   display: inline-flex;
   align-items: center;
@@ -308,6 +317,29 @@ button:active,
   background: rgba(37, 99, 235, 0.18);
   color: var(--accent);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.relationship-badge.network {
+  background: rgba(15, 23, 42, 0.1);
+  color: rgba(15, 23, 42, 0.75);
+}
+
+.dep-badge {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.4rem;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: rgba(22, 163, 74, 0.18);
+  color: #166534;
+}
+
+.dependencies table tbody tr.focused-row {
+  background: rgba(219, 234, 254, 0.6);
 }
 
 .empty-state {


### PR DESCRIPTION
## Summary
- re-render the hierarchy when graph selections change so cards reflect the active node
- add a network focus badge and styling to hierarchy cards tied to graph selections
- highlight dependency rows connected to focused nodes for clearer context

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0a3e0a7288325a9475d6f57005f19