### PR TITLE
Add full graph view toggle and refine dependency highlighting

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -37,7 +37,8 @@
           <p class="panel-help">
             Start with the Level 2 milestones. Once you choose a card, the immediate Level 3
             work appears here and in the network. Continue drilling down by selecting nodes in
-            the visualization to reveal their direct predecessors and successors.
+            the visualization to spotlight their direct dependencies. You can also switch to a
+            full network view from the graph controls.
           </p>
           <div class="panel-subhead">Current path</div>
           <div id="level-controls" class="level-controls"></div>
@@ -60,8 +61,8 @@
           <button id="fit-graph" type="button">Fit to screen</button>
           <button id="reset-selection" type="button">Clear selection</button>
           <label class="toggle">
-            <input type="checkbox" id="auto-expand" checked />
-            <span>Auto-include direct predecessors and successors</span>
+            <input type="checkbox" id="show-full-graph" />
+            <span>Show full graph</span>
           </label>
         </div>
         <div class="dependencies" id="dependency-table"></div>


### PR DESCRIPTION
## Summary
- replace the auto-include toggle with a full graph view control and updated sidebar guidance
- rework the legend and graph rendering to highlight selected dependencies while dimming unrelated nodes
- reset the full graph mode when loading a new dataset to avoid stale state

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0ab6d24c88325b407701d303404fc