### PR TITLE
Move task editor below visualization

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -46,12 +46,6 @@
           <div id="hierarchy" class="hierarchy"></div>
         </div>
 
-        <div class="panel">
-          <h2>Task details</h2>
-          <div id="task-details" class="task-details empty">
-            <p>Select a node in the network to see its attributes here.</p>
-          </div>
-        </div>
       </section>
 
       <section class="visualization">
@@ -64,6 +58,12 @@
             <input type="checkbox" id="show-full-graph" />
             <span>Show full graph</span>
           </label>
+        </div>
+        <div class="panel task-panel">
+          <h2>Task details</h2>
+          <div id="task-details" class="task-details empty">
+            <p>Select a task from the graph or hierarchy to edit its attributes, manage dependencies, or remove it.</p>
+          </div>
         </div>
         <div class="dependencies">
           <div id="dependency-focus" class="dependency-focus"></div>

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -492,6 +492,7 @@ button:active,
   padding: 0.55rem 0.75rem;
   font-size: 0.85rem;
   background: rgba(255, 255, 255, 0.9);
+  color: var(--text);
 }
 
 .task-field input:focus {
@@ -531,6 +532,16 @@ button:active,
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.task-panel {
+  align-self: stretch;
+  padding: 1.5rem clamp(1.25rem, 2vw + 1rem, 1.75rem);
+}
+
+.task-panel h2 {
+  margin-top: 0;
+  margin-bottom: 0.85rem;
 }
 
 .legend {


### PR DESCRIPTION
## Summary
- relocate the task details editor into the visualization column so it sits directly under the network view
- update the empty-state message to reflect the new interaction entry point
- ensure editable inputs use the primary text color for proper contrast
- tweak panel styling to stretch across the visualization area

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d1e4927828832588b9aac8bc8ca01e