### PR TITLE
Move task details panel below visualization pane

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -59,12 +59,6 @@
             <span>Show full graph</span>
           </label>
         </div>
-        <div class="panel task-panel">
-          <h2>Task details</h2>
-          <div id="task-details" class="task-details empty">
-            <p>Select a task from the graph or hierarchy to edit its attributes, manage dependencies, or remove it.</p>
-          </div>
-        </div>
         <div class="dependencies">
           <div id="dependency-focus" class="dependency-focus"></div>
           <details id="dependency-panel" class="dependency-accordion">
@@ -76,6 +70,15 @@
               <div id="dependency-table"></div>
             </div>
           </details>
+        </div>
+      </section>
+
+      <section class="task-details-region">
+        <div class="panel task-panel">
+          <h2>Task details</h2>
+          <div id="task-details" class="task-details empty">
+            <p>Select a task from the graph or hierarchy to edit its attributes, manage dependencies, or remove it.</p>
+          </div>
         </div>
       </section>
     </main>

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -534,6 +534,15 @@ button:active,
   gap: 1rem;
 }
 
+.task-details-region {
+  grid-column: 2;
+  display: flex;
+}
+
+.task-details-region .task-panel {
+  flex: 1 1 auto;
+}
+
 .task-panel {
   align-self: stretch;
   padding: 1.5rem clamp(1.25rem, 2vw + 1rem, 1.75rem);
@@ -748,6 +757,10 @@ button:active,
 @media (max-width: 1100px) {
   .layout {
     grid-template-columns: 1fr;
+  }
+
+  .task-details-region {
+    grid-column: 1 / -1;
   }
 
   .graph {


### PR DESCRIPTION
## Summary
- relocate the task details card to its own section positioned beneath the visualization pane
- add layout styles so the new task details section spans the visualization column on large screens and full width on smaller screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1e620a4188325bfdbb9d1e5b48add