### PR TITLE
Align task details panel beneath visualization

### DIFF
--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -100,6 +100,9 @@ button:active,
 .layout {
   display: grid;
   grid-template-columns: minmax(320px, 380px) 1fr;
+  grid-template-areas:
+    "sidebar visualization"
+    "sidebar task";
   gap: 1.5rem;
   padding: clamp(1.5rem, 2vw + 1rem, 3rem);
 }
@@ -108,7 +111,9 @@ button:active,
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  grid-area: sidebar;
 }
+
 
 .panel {
   background: rgba(255, 255, 255, 0.85);
@@ -532,11 +537,12 @@ button:active,
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  grid-area: visualization;
 }
 
 .task-details-region {
-  grid-column: 2;
   display: flex;
+  grid-area: task;
 }
 
 .task-details-region .task-panel {
@@ -757,6 +763,10 @@ button:active,
 @media (max-width: 1100px) {
   .layout {
     grid-template-columns: 1fr;
+    grid-template-areas:
+      "sidebar"
+      "visualization"
+      "task";
   }
 
   .task-details-region {


### PR DESCRIPTION
## Summary
- update the main layout grid to use template areas so the sidebar spans both rows while the task details occupy the visualization column
- assign grid areas to the visualization and task detail sections to keep them grouped together in the right pane
- ensure the responsive single-column layout orders the panels with the task details beneath the graph

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1e7a573bc83258058a7509400ab21