### PR TITLE
Fix inferred dependency direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,13 @@ No runtime installation is required beyond a modern web browser. To keep setup l
 
 1. **Clone the repository** (or download the ZIP).
 2. **Open a terminal** in the project root.
-3. **Start a lightweight static server**:
+3. **Start the preprocessing server** (serves the web UI and cleans uploads):
 
-   ### macOS (built-in Python 3)
    ```bash
-   python3 -m http.server 8000 --directory webapp
+   python server.py --port 8000
    ```
 
-   ### Windows (PowerShell with Python installed)
-   ```powershell
-   py -3 -m http.server 8000 --directory webapp
-   ```
-
-   > 💡 If `py` is unavailable, try `python` instead. The command prints the URL you can open in the browser (`http://0.0.0.0:8000` or `http://localhost:8000`).
+   The server streams and cleans uploaded workbooks before handing them to the front-end. Large workbooks may take a few seconds to process while hierarchy-based dependencies are restored.
 
 4. **Open the app** in your preferred browser at `http://localhost:8000`.
 5. **Load data**:
@@ -78,7 +72,8 @@ The first sheet of the workbook is parsed. A header row is required. The followi
    - **Clear selection** empties the detail drawer.
    - **Auto-include context** adds the direct predecessors and successors of selected tasks so that dependencies are never orphaned.
 4. **Task detail drawer** – Click a node to surface its metadata, predecessor/successor IDs, and status badges (critical, learning plan).
-5. **Dependency table** – Lists every predecessor → successor relationship for the currently visible tasks, including dependency type.
+5. **Dependency cleaning** – When an Excel file is uploaded the app pauses briefly while the Python pipeline inspects indentation and fills in missing predecessor/successor links.
+6. **Dependency table** – Lists every predecessor → successor relationship for the currently visible tasks, including dependency type.
 
 Tip: For complex reviews, start with only L2 milestones selected, then progressively expand lower levels or specific scopes while discussing with stakeholders.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An interactive, browser-based tool for validating complex critical path schedule
 - **Interactive dependency graph** – Visualize predecessor/successor relationships, auto-include nearby context, and highlight task metadata.
 - **Dependency typing** – Add a `Dependency Type` column (FS/SS/SF/FF) to distinguish relationships; otherwise Finish-to-Start (FS) is assumed.
 - **Stakeholder-friendly UI** – Styled for projection or screen sharing; no coding experience required.
+- **Cleaning feedback & fallback** – Upload status messages highlight when indentation restored missing links and warn if the server falls back to raw workbook data.
 
 A lightweight sample dataset is included in [`webapp/data/sample_schedule.json`](webapp/data/sample_schedule.json) and the repository ships with the stakeholder workbook `CPS_Rules_comm_LPA_Readiness.xlsx` for real-world testing.
 
@@ -30,7 +31,7 @@ No runtime installation is required beyond a modern web browser. To keep setup l
    python server.py --port 8000
    ```
 
-   The server streams and cleans uploaded workbooks before handing them to the front-end. Large workbooks may take a few seconds to process while hierarchy-based dependencies are restored.
+   The server streams and cleans uploaded workbooks before handing them to the front-end. Large workbooks may take a few seconds to process while hierarchy-based dependencies are restored. If the server cannot be reached, the UI will fall back to the uncleaned workbook and display a warning banner.
 
 4. **Open the app** in your preferred browser at `http://localhost:8000`.
 5. **Load data**:

--- a/cps_preprocessor.py
+++ b/cps_preprocessor.py
@@ -1,0 +1,372 @@
+"""Preprocess CPS Excel workbooks to restore implicit dependencies."""
+from __future__ import annotations
+
+import io
+import json
+import re
+import sys
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+from xml.etree import ElementTree as ET
+from zipfile import ZipFile
+
+
+@dataclass
+class WorkbookData:
+    headers: List[str]
+    rows: List[Dict[str, str]]
+    header_lookup: Dict[str, str]
+    indent_by_row: List[int]
+
+
+@dataclass
+class PreprocessMetadata:
+    added_predecessors: int = 0
+    added_successors: int = 0
+
+    @property
+    def cleaned(self) -> bool:
+        return (self.added_predecessors + self.added_successors) > 0
+
+    def to_dict(self) -> Dict[str, int | bool]:
+        return {
+            "addedPredecessors": self.added_predecessors,
+            "addedSuccessors": self.added_successors,
+            "cleaned": self.cleaned,
+        }
+
+
+def preprocess_excel(data: bytes) -> Tuple[List[Dict[str, str]], Dict[str, int | bool]]:
+    """Parse and clean an uploaded Excel workbook."""
+    workbook = _read_workbook(data)
+    cleaned_rows, metadata = _fill_missing_dependencies(workbook)
+    return cleaned_rows, metadata.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Workbook parsing helpers
+
+
+def _read_workbook(data: bytes) -> WorkbookData:
+    with ZipFile(io.BytesIO(data)) as zf:
+        shared_strings = _read_shared_strings(zf)
+        style_indents = _read_style_indents(zf)
+        sheet_path = "xl/worksheets/sheet1.xml"
+        if sheet_path not in zf.namelist():
+            raise ValueError("Unable to locate the first worksheet in the workbook.")
+        with zf.open(sheet_path) as sheet_stream:
+            headers, header_lookup, rows, indent_by_row = _parse_sheet_stream(
+                sheet_stream, shared_strings, style_indents
+            )
+
+    if not headers or not rows:
+        raise ValueError("The uploaded workbook does not contain any rows.")
+
+    return WorkbookData(headers=headers, rows=rows, header_lookup=header_lookup, indent_by_row=indent_by_row)
+
+
+def _parse_sheet_stream(
+    stream: io.BufferedReader, shared_strings: List[str], style_indents: Dict[int, int]
+) -> Tuple[List[str], Dict[str, str], List[Dict[str, str]], List[int]]:
+    context = ET.iterparse(stream, events=("start", "end"))
+    _, root = next(context)
+
+    headers: List[str] = []
+    header_lookup: Dict[str, str] = {}
+    rows: List[Dict[str, str]] = []
+    indent_by_row: List[int] = []
+    task_name_index: Optional[int] = None
+
+    for event, element in context:
+        if event != "end" or _local_name(element.tag) != "row":
+            continue
+
+        row_number = int(element.attrib.get("r", "0"))
+        cells: Dict[int, Tuple[str, int]] = {}
+
+        for cell in element:
+            if _local_name(cell.tag) != "c":
+                continue
+            reference = cell.attrib.get("r", "")
+            column_letter = _column_from_reference(reference)
+            if column_letter is None:
+                continue
+            column_index = _column_index(column_letter)
+            style_index = int(cell.attrib.get("s", "0"))
+            indent = style_indents.get(style_index, 0)
+            value = _read_cell_value(cell, shared_strings)
+            cells[column_index] = (value, indent)
+
+        if row_number == 1:
+            if cells:
+                max_index = max(cells.keys())
+                headers = ["" for _ in range(max_index + 1)]
+                for index in range(max_index + 1):
+                    value = cells.get(index, ("", 0))[0]
+                    header_value = value or ""
+                    if header_value:
+                        normalized = _normalize_key(header_value)
+                        if normalized == "rtask name":
+                            header_value = "Task Name"
+                            normalized = "task name"
+                        headers[index] = header_value
+                        header_lookup[normalized] = header_value
+                    else:
+                        headers[index] = ""
+                task_name_header = _resolve_header(header_lookup, ("task name", "name"))
+                task_name_index = headers.index(task_name_header) if task_name_header else None
+        elif headers:
+            row_dict: Dict[str, str] = {}
+            indent = 0
+            for index, (value, indent_candidate) in cells.items():
+                if index >= len(headers):
+                    continue
+                header = headers[index]
+                if not header:
+                    continue
+                if task_name_index is not None and index == task_name_index:
+                    indent = indent_candidate
+                row_dict[header] = _stringify(value)
+            rows.append(row_dict)
+            indent_by_row.append(indent)
+
+        element.clear()
+
+    root.clear()
+    return headers, header_lookup, rows, indent_by_row
+
+def _read_shared_strings(zf: ZipFile) -> List[str]:
+    if "xl/sharedStrings.xml" not in zf.namelist():
+        return []
+    with zf.open("xl/sharedStrings.xml") as shared_file:
+        tree = ET.parse(shared_file)
+    root = tree.getroot()
+    namespace = {"a": _namespace(root)}
+    strings: List[str] = []
+    for si in root.findall("a:si", namespace):
+        text_parts = [t.text or "" for t in si.findall(".//a:t", namespace)]
+        strings.append("".join(text_parts))
+    return strings
+
+
+def _read_style_indents(zf: ZipFile) -> Dict[int, int]:
+    if "xl/styles.xml" not in zf.namelist():
+        return {}
+    with zf.open("xl/styles.xml") as styles_file:
+        tree = ET.parse(styles_file)
+    root = tree.getroot()
+    namespace = {"a": _namespace(root)}
+    mapping: Dict[int, int] = {}
+    cell_xfs = root.find("a:cellXfs", namespace)
+    if cell_xfs is None:
+        return mapping
+    for index, xf in enumerate(cell_xfs.findall("a:xf", namespace)):
+        alignment = xf.find("a:alignment", namespace)
+        if alignment is not None and "indent" in alignment.attrib:
+            try:
+                mapping[index] = int(alignment.attrib["indent"])
+            except ValueError:
+                continue
+    return mapping
+
+
+def _read_cell_value(cell: ET.Element, shared_strings: List[str]) -> str:
+    cell_type = cell.attrib.get("t")
+    if cell_type == "s":
+        index_text = _value_element_text(cell)
+        if not index_text:
+            return ""
+        try:
+            return shared_strings[int(index_text)]
+        except (ValueError, IndexError):
+            return ""
+    if cell_type == "inlineStr":
+        text_parts = [node.text or "" for node in cell.iter() if _local_name(node.tag) == "t"]
+        return "".join(text_parts)
+    value_text = _value_element_text(cell)
+    return value_text or ""
+
+
+# ---------------------------------------------------------------------------
+# Dependency restoration
+
+
+def _fill_missing_dependencies(workbook: WorkbookData) -> Tuple[List[Dict[str, str]], PreprocessMetadata]:
+    id_header = _resolve_header(workbook.header_lookup, ("taskid", "task id", "id"))
+    name_header = _resolve_header(workbook.header_lookup, ("task name", "rtask name", "name"))
+    level_header = _resolve_header(workbook.header_lookup, ("task level", "level"))
+    predecessors_header = _resolve_header(
+        workbook.header_lookup, ("predecessors ids", "predecessor ids", "predecessors")
+    )
+    successors_header = _resolve_header(
+        workbook.header_lookup, ("successors ids", "successor ids", "successors")
+    )
+
+    if not id_header or not name_header:
+        raise ValueError("The workbook must include 'Task ID' and 'Task Name' columns.")
+
+    metadata = PreprocessMetadata()
+    stack: List[Dict[str, object]] = []
+
+    for index, row in enumerate(workbook.rows):
+        task_id = _stringify(row.get(id_header, ""))
+        task_name = _stringify(row.get(name_header, ""))
+        if not task_id or not task_name:
+            continue
+
+        level_value = row.get(level_header, "") if level_header else ""
+        level_number = _parse_level(level_value)
+        predecessors = _split_ids(row.get(predecessors_header, "")) if predecessors_header else []
+        successors = _split_ids(row.get(successors_header, "")) if successors_header else []
+        predecessors_were_empty = not predecessors
+        successors_were_empty = not successors
+        current_indent = workbook.indent_by_row[index] if index < len(workbook.indent_by_row) else 0
+
+        while stack and stack[-1]["indent"] >= current_indent:
+            stack.pop()
+
+        parent = stack[-1] if stack else None
+        if parent:
+            parent_level = parent.get("level")
+            if _is_valid_parent(level_number, parent_level):
+                if predecessors_header and parent["can_fill_predecessors"]:
+                    parent_predecessors: List[str] = parent["predecessors"]  # type: ignore[assignment]
+                    if task_id not in parent_predecessors:
+                        parent_predecessors.append(task_id)
+                        parent_row: Dict[str, str] = parent["row"]  # type: ignore[assignment]
+                        parent_row[predecessors_header] = _join_ids(parent_predecessors)
+                        metadata.added_predecessors += 1
+                if successors_header and successors_were_empty:
+                    if parent["id"] not in successors:
+                        successors.append(parent["id"])  # type: ignore[arg-type]
+                        row[successors_header] = _join_ids(successors)
+                        metadata.added_successors += 1
+                        successors_were_empty = False
+
+        stack.append(
+            {
+                "id": task_id,
+                "indent": current_indent,
+                "level": level_number,
+                "row": row,
+                "predecessors": predecessors,
+                "can_fill_predecessors": predecessors_were_empty,
+                "successors": successors,
+            }
+        )
+
+    return workbook.rows, metadata
+
+
+def _is_valid_parent(child_level: Optional[int], parent_level: Optional[int]) -> bool:
+    if child_level is None or parent_level is None:
+        return True
+    return child_level == parent_level + 1
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit('}', 1)[-1] if '}' in tag else tag
+
+
+def _value_element_text(cell: ET.Element) -> str:
+    for child in cell:
+        if _local_name(child.tag) == 'v' and child.text:
+            return child.text
+    return ""
+
+
+def _namespace(element: ET.Element) -> str:
+    if element.tag.startswith("{"):
+        return element.tag.split("}", 1)[0].strip("{")
+    return ""
+
+
+def _column_from_reference(reference: str) -> Optional[str]:
+    match = re.match(r"([A-Z]+)", reference)
+    return match.group(1) if match else None
+
+
+def _column_index(column: str) -> int:
+    index = 0
+    for char in column:
+        index = index * 26 + (ord(char) - 64)
+    return index - 1
+
+
+def _normalize_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", value.strip().lower())
+
+
+def _resolve_header(mapping: Dict[str, str], options: Iterable[str]) -> Optional[str]:
+    for option in options:
+        normalized = _normalize_key(option)
+        if normalized in mapping:
+            return mapping[normalized]
+    return None
+
+
+def _stringify(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and value.is_integer():
+            return str(int(value))
+        return str(value)
+    return str(value)
+
+
+def _split_ids(value: object) -> List[str]:
+    text = _stringify(value)
+    if not text:
+        return []
+    parts = re.split(r"[,;\n]", text)
+    return [part.strip() for part in parts if part.strip()]
+
+
+def _join_ids(values: List[str]) -> str:
+    return ", ".join(dict.fromkeys(values))
+
+
+def _parse_level(value: object) -> Optional[int]:
+    text = _stringify(value)
+    if not text:
+        return None
+    if text.isdigit():
+        return int(text)
+    match = re.search(r"(\d+)", text)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# CLI helper for manual execution
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Clean CPS workbooks by inferring hierarchy dependencies.")
+    parser.add_argument("input", help="Path to the source .xlsx workbook")
+    parser.add_argument("output", nargs="?", help="Optional JSON file for the cleaned rows")
+    args = parser.parse_args()
+
+    with open(args.input, "rb") as source:
+        records, metadata = preprocess_excel(source.read())
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as destination:
+            json.dump({"records": records, "metadata": metadata}, destination, indent=2)
+    else:
+        json.dump({"records": records, "metadata": metadata}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -13,6 +13,9 @@
     />
   </head>
   <body>
+    <div id="processing-notice" class="processing-notice" role="status" aria-live="polite" hidden>
+      Cleaning schedule dependencies…
+    </div>
     <header class="app-header">
       <div>
         <h1>Critical Path Schedule Visualizer</h1>

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -32,6 +32,7 @@
         <button id="load-sample" type="button">Load sample data</button>
       </div>
     </header>
+    <p id="upload-status" class="upload-status" role="status" aria-live="polite" hidden></p>
 
     <main class="layout">
       <section class="sidebar" id="sidebar">

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -55,6 +55,20 @@ body {
   display: none;
 }
 
+.upload-status {
+  margin: 0;
+  padding: 0.75rem clamp(1.5rem, 3vw + 1rem, 3.5rem);
+  background: rgba(15, 23, 42, 0.08);
+  color: rgba(15, 23, 42, 0.8);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.upload-status[hidden] {
+  display: none;
+}
+
 .app-header {
   display: flex;
   justify-content: space-between;
@@ -101,6 +115,13 @@ button {
   box-shadow: 0 10px 20px rgba(37, 99, 235, 0.2);
 }
 
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
 button:hover,
 .file-input:hover span {
   transform: translateY(-1px);
@@ -121,6 +142,16 @@ button:active,
   background: white;
   color: var(--accent);
   box-shadow: 0 10px 20px rgba(15, 23, 42, 0.1);
+}
+
+.file-input.disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.file-input.disabled span {
+  pointer-events: none;
 }
 
 .file-input input[type="file"] {

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -22,6 +22,39 @@ body {
   color: var(--text);
 }
 
+.processing-notice {
+  position: fixed;
+  top: 1.25rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(15, 23, 42, 0.95);
+  color: var(--text-light);
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.3);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  pointer-events: none;
+}
+
+.processing-notice::before {
+  content: "";
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 50%;
+  border: 2px solid rgba(148, 163, 184, 0.4);
+  border-top-color: #38bdf8;
+  animation: spin 0.9s linear infinite;
+}
+
+.processing-notice[hidden] {
+  display: none;
+}
+
 .app-header {
   display: flex;
   justify-content: space-between;
@@ -758,6 +791,12 @@ button:active,
 .status-pill.learning {
   background: rgba(234, 179, 8, 0.16);
   color: #a16207;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @media (max-width: 1100px) {


### PR DESCRIPTION
## Summary
- add a streaming Excel preprocessing pipeline that restores hierarchy-based dependencies when predecessor/successor IDs are missing
- expose the pipeline through a lightweight Python server and update the front-end to call it while showing a cleaning status indicator
- refresh documentation and styles to describe the new upload workflow and feedback message
- ensure lower-level tasks are recorded as predecessors of their parents when dependency cells are empty

## Testing
- `python - <<'PY' ...` (runs `preprocess_excel` against `cps_rules_level_4.xlsx` and reports cleaned dependency counts)
- `python - <<'PY' ...` (verifies a Level 2 task now lists its Level 3 children as predecessors)


------
https://chatgpt.com/codex/tasks/task_e_68d9d932c684832588ef426098b81f86