### PR TITLE
Add missing JPype1 dependency for cps_tool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+JPype1
 mpxj


### PR DESCRIPTION
## Summary
- add the JPype1 dependency required by the mpxj-based cps_tool converter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd8c300e508325b925ac23c7d723cb