### PR TITLE
Fix mpxj TimeUnit import for newer releases

### DIFF
--- a/cps_tool/mpp_converter.py
+++ b/cps_tool/mpp_converter.py
@@ -6,7 +6,23 @@ from datetime import datetime
 from pathlib import Path
 from typing import List
 
-from mpxj import TimeUnit
+try:  # pragma: no cover - import resolution depends on mpxj version
+    from mpxj.enums import TimeUnit  # type: ignore[attr-defined]
+except ModuleNotFoundError as exc:  # pragma: no cover - missing dependency
+    raise ImportError(
+        "mpxj is required to convert Microsoft Project schedules. "
+        "Install the package with its optional Java dependencies as "
+        "documented in the README."
+    ) from exc
+except ImportError:  # pragma: no cover - fallback for older releases
+    try:
+        from mpxj import TimeUnit  # type: ignore[no-redef]
+    except ModuleNotFoundError as exc:  # pragma: no cover - missing dependency
+        raise ImportError(
+            "mpxj is required to convert Microsoft Project schedules. "
+            "Install the package with its optional Java dependencies as "
+            "documented in the README."
+        ) from exc
 from mpxj.reader import UniversalProjectReader
 
 from .models import DependencySpec, TaskSpec


### PR DESCRIPTION
## Summary
- allow importing TimeUnit from either mpxj.enums or mpxj for compatibility
- raise a clearer error message when the mpxj dependency is missing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd8e28749c832594da1bbe169cf90f