### PR TITLE
Handle optional mpxj import lazily

### DIFF
--- a/notebooks/mpxj_environment.ipynb
+++ b/notebooks/mpxj_environment.ipynb
@@ -1,0 +1,84 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# MPXJ environment check\n",
+        "\n",
+        "This notebook documents how to create a virtual environment using the project's `requirements.txt` file and verifies that the optional `mpxj` dependency is available before running conversions."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 1. Create and activate a virtual environment\n",
+        "\n",
+        "Run the following commands in a terminal to create a fresh environment and install the dependencies. If the installation fails, double-check that outbound internet access is available (both `JPype1` and `mpxj` are hosted on PyPI).\n",
+        "\n",
+        "```bash\n",
+        "python -m venv .venv\n",
+        "source .venv/bin/activate  # On Windows use: .venv\\Scripts\\activate\n",
+        "python -m pip install --upgrade pip\n",
+        "python -m pip install -r requirements.txt\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import importlib\n",
+        "from pathlib import Path\n",
+        "\n",
+        "try:\n",
+        "    mpp_converter = importlib.import_module('cps_tool.mpp_converter')\n",
+        "    print('MPXJ import available.')\n",
+        "except ImportError as exc:\n",
+        "    print('mpxj is not installed:', exc)\n",
+        "    print('Install the requirements and restart the kernel before running conversions.')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 2. Convert an MPP file to CSV (optional)\n",
+        "\n",
+        "Once the dependency check passes, run the following cell to convert an `.mpp` file. Update the paths as needed for your dataset."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from datetime import datetime\n",
+        "from cps_tool import mpp_converter\n",
+        "\n",
+        "input_path = Path('Generic CPS for I-O.mpp')\n",
+        "output_path = Path('output/tasks.csv')\n",
+        "\n",
+        "csv_path = mpp_converter.convert_mpp_to_csv(input_path, output_path)\n",
+        "print('Wrote CSV to', csv_path)"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/tests/test_mpp_converter.py
+++ b/tests/test_mpp_converter.py
@@ -1,0 +1,136 @@
+import importlib
+import sys
+import types
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest import mock
+
+
+class MpxjImportTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Ensure we reload the module with a clean cache between tests.
+        if "cps_tool.mpp_converter" in sys.modules:
+            module = sys.modules["cps_tool.mpp_converter"]
+            try:
+                module._load_mpxj.cache_clear()  # type: ignore[attr-defined]
+            except AttributeError:
+                pass
+            del sys.modules["cps_tool.mpp_converter"]
+
+    def tearDown(self) -> None:
+        if "cps_tool.mpp_converter" in sys.modules:
+            module = sys.modules["cps_tool.mpp_converter"]
+            try:
+                module._load_mpxj.cache_clear()  # type: ignore[attr-defined]
+            except AttributeError:
+                pass
+            del sys.modules["cps_tool.mpp_converter"]
+
+    def test_extract_tasks_requires_mpxj(self) -> None:
+        mpp_converter = importlib.import_module("cps_tool.mpp_converter")
+        with self.assertRaises(ImportError) as ctx:
+            mpp_converter.extract_tasks_from_mpp(Path("dummy.mpp"))
+        self.assertIn("mpxj is required", str(ctx.exception))
+
+    def test_extract_tasks_with_stubbed_mpxj(self) -> None:
+        fake_timeunit = types.SimpleNamespace(DAYS="days")
+
+        class FakeDuration:
+            def __init__(self, value: float) -> None:
+                self._value = value
+
+            def convert(self, unit: object) -> types.SimpleNamespace:
+                return types.SimpleNamespace(duration=self._value)
+
+        class FakeTask:
+            def __init__(self) -> None:
+                self.unique_id = 1
+                self.name = "Example"
+                self.duration = FakeDuration(5.5)
+                self.predecessors = []
+                self.milestone = False
+                self.outline_level = 2
+                self.constraint_type = types.SimpleNamespace(name="ASAP")
+                self.constraint_date = datetime(2023, 1, 1, 8, 0)
+                self.calendar = types.SimpleNamespace(name="Standard")
+                self.start = datetime(2023, 1, 1, 8, 0)
+                self.finish = datetime(2023, 1, 2, 17, 0)
+                self.summary = False
+
+        class FakeProject:
+            def __init__(self) -> None:
+                self.tasks = [FakeTask()]
+
+        class FakeReader:
+            def read(self, path: str) -> FakeProject:
+                self.path = path
+                return FakeProject()
+
+        fake_reader_class = FakeReader
+
+        with mock.patch("cps_tool.mpp_converter._load_mpxj", return_value=(fake_timeunit, fake_reader_class)):
+            mpp_converter = importlib.import_module("cps_tool.mpp_converter")
+            tasks = mpp_converter.extract_tasks_from_mpp(Path("dummy.mpp"))
+
+        self.assertEqual(len(tasks), 1)
+        task = tasks[0]
+        self.assertEqual(task.uid, 1)
+        self.assertEqual(task.name, "Example")
+        self.assertAlmostEqual(task.duration_days, 5.5)
+        self.assertEqual(task.outline_level, 2)
+        self.assertEqual(task.constraint_type, "ASAP")
+        self.assertIsNotNone(task.constraint_date)
+        self.assertEqual(task.calendar_name, "Standard")
+
+    def test_convert_mpp_to_csv_uses_stubbed_reader(self) -> None:
+        fake_timeunit = types.SimpleNamespace(DAYS="days")
+
+        class FakeDuration:
+            def __init__(self, value: float) -> None:
+                self._value = value
+
+            def convert(self, unit: object) -> types.SimpleNamespace:
+                return types.SimpleNamespace(duration=self._value)
+
+        class FakeTask:
+            def __init__(self) -> None:
+                self.unique_id = 1
+                self.name = "Example"
+                self.duration = FakeDuration(1.0)
+                self.predecessors = []
+                self.milestone = True
+                self.outline_level = 1
+                self.constraint_type = None
+                self.constraint_date = None
+                self.calendar = types.SimpleNamespace(name=None)
+                self.start = None
+                self.finish = None
+                self.summary = False
+
+        class FakeProject:
+            def __init__(self) -> None:
+                self.tasks = [FakeTask()]
+
+        class FakeReader:
+            def read(self, path: str) -> FakeProject:
+                return FakeProject()
+
+        fake_reader_class = FakeReader
+
+        with mock.patch("cps_tool.mpp_converter._load_mpxj", return_value=(fake_timeunit, fake_reader_class)):
+            mpp_converter = importlib.import_module("cps_tool.mpp_converter")
+            output_path = Path("tests/tmp_output.csv")
+            try:
+                csv_path = mpp_converter.convert_mpp_to_csv(Path("dummy.mpp"), output_path)
+                self.assertTrue(csv_path.exists())
+                contents = output_path.read_text(encoding="utf-8").splitlines()
+                self.assertEqual(contents[0], "uid,name,duration_days,is_milestone,outline_level,constraint_type,constraint_date,calendar,predecessors,start,finish")
+                self.assertIn("Example", contents[1])
+            finally:
+                if output_path.exists():
+                    output_path.unlink()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- lazily import the mpxj dependency so the package can be used without the optional converter installed
- add unit tests that exercise the converter with stubbed mpxj modules and verify helpful error messages
- provide a Jupyter notebook outlining environment setup and a dependency check for running conversions

## Testing
- python -m unittest discover -s tests -p 'test_*.py'


------
https://chatgpt.com/codex/tasks/task_e_68dd902fb1588325ba2783ce7e6b7b11