### PR TITLE
Handle CPS dependency cycles automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ python -m cps_tool.cli calculate output/tasks.csv \
   --output output/cps_schedule.csv
 ```
 
-Both commands print a short summary to stdout. When `--output` is provided the calculator writes a CSV containing earliest/latest dates, float, and a critical-path flag for every task.
+Both commands print a short summary to stdout. When `--output` is provided the calculator writes a CSV containing earliest/latest dates, float, and a critical-path flag for every task. If dependency cycles are discovered they are reported during execution, the blocking dependency is removed automatically, and a cycle-adjusted CPS CSV is written alongside the summary.
 
 ### 7.3. Embedding as a Python module
 
@@ -171,6 +171,12 @@ result = calculate_schedule(tasks, project_start=datetime(2023, 1, 2, 8, 0), cal
 print("Project finish:", result.project_finish.isoformat())
 for task in result.critical_path():
     print("Critical:", task.spec.uid, task.spec.name)
+if result.cycle_resolutions:
+    print("Resolved cycles:")
+    for resolution in result.cycle_resolutions:
+        print("  ", resolution.formatted_cycle())
+    if result.cycle_adjusted_csv:
+        print("  Modified CPS written to", result.cycle_adjusted_csv)
 ```
 
 The `ScheduleResult.to_rows()` helper returns dictionaries that can be written back to CSV (the CLI uses the same method). The calculator honours Finish-to-Start, Start-to-Start, Finish-to-Finish, and Start-to-Finish dependencies, plus common constraint types such as “Must Start On” and “Finish No Earlier Than”.

--- a/cps_tool/cli.py
+++ b/cps_tool/cli.py
@@ -85,6 +85,20 @@ def _handle_calculate(args: argparse.Namespace) -> None:
         print(f"  Working duration: {duration_hours:.2f} hours ({duration_days:.2f} days)")
     critical_count = sum(1 for task in result.tasks if task.is_critical)
     print(f"  Critical tasks: {critical_count}")
+    if result.cycle_resolutions:
+        print("  Dependency cycles detected and resolved:")
+        for resolution in result.cycle_resolutions:
+            print(f"    Cycle: {resolution.formatted_cycle()}")
+            dependency = resolution.removed_dependency
+            relation = (dependency.relation_type or "FS").upper()
+            lag = f"{dependency.lag_days:g}"
+            print(
+                "      Removed dependency: "
+                f"{resolution.removed_from_task_uid} ({resolution.removed_from_task_name}) "
+                f"<- {dependency.predecessor_uid} [{relation} lag {lag} days]"
+            )
+        if result.cycle_adjusted_csv:
+            print(f"  Cycle-adjusted CPS written to {result.cycle_adjusted_csv}")
     if args.output:
         output_path = Path(args.output)
         _write_schedule(output_path, result.to_rows())

--- a/cps_tool/models.py
+++ b/cps_tool/models.py
@@ -19,6 +19,26 @@ class DependencySpec:
 
 
 @dataclass(slots=True)
+class CycleResolution:
+    """Describe how a dependency cycle was resolved."""
+
+    cycle_task_uids: List[int]
+    cycle_task_names: List[str]
+    removed_from_task_uid: int
+    removed_from_task_name: str
+    removed_dependency: DependencySpec
+
+    def formatted_cycle(self) -> str:
+        """Return a user-friendly representation of the cycle."""
+
+        segments = [
+            f"{uid} ({name})"
+            for uid, name in zip(self.cycle_task_uids, self.cycle_task_names)
+        ]
+        return " -> ".join(segments)
+
+
+@dataclass(slots=True)
 class TaskSpec:
     """Normalized task information extracted from the Microsoft Project file."""
 
@@ -62,6 +82,8 @@ class ScheduleResult:
     project_start: datetime
     project_finish: datetime
     tasks: List[ScheduledTask]
+    cycle_resolutions: List[CycleResolution] = field(default_factory=list)
+    cycle_adjusted_csv: Optional[str] = None
 
     def critical_path(self) -> List[ScheduledTask]:
         return [task for task in self.tasks if task.is_critical]


### PR DESCRIPTION
## Summary
- add dependency cycle detection/removal to the calculator and write an adjusted CPS CSV when needed
- surface resolved cycle information through the CLI output and schedule result metadata
- update the README programmatic example to demonstrate accessing cycle resolution details

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd987aef1c832582ad8f42a97723ce