### PR TITLE
Handle empty successor candidates in backward pass

### DIFF
--- a/cps_tool/calculator.py
+++ b/cps_tool/calculator.py
@@ -460,7 +460,10 @@ def _backward_pass(
                     )
                 candidate_finish = calendar.align_finish(candidate_finish)
                 candidate_finishes.append(candidate_finish)
-            latest_finish_limit = min(candidate_finishes)
+            if candidate_finishes:
+                latest_finish_limit = min(candidate_finishes)
+            else:
+                latest_finish_limit = project_finish
         else:
             latest_finish_limit = project_finish
         latest_start = calendar.subtract_work_duration(


### PR DESCRIPTION
## Summary
- prevent `min()` from being called on an empty list when all successor dependencies are skipped during the backward pass
- fall back to the project finish date when no valid successor candidates are available

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cps_tool')*

------
https://chatgpt.com/codex/tasks/task_e_68dda599d90c83258d6556c9aa75abdb