### PR TITLE
Add CSV export helper for calculated schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,5 @@ if result.cycle_resolutions:
 ```
 
 The `ScheduleResult.to_rows()` helper returns dictionaries that can be written back to CSV (the CLI uses the same method). The calculator honours Finish-to-Start, Start-to-Start, Finish-to-Finish, and Start-to-Finish dependencies, plus common constraint types such as “Must Start On” and “Finish No Earlier Than”.
+
+Call `ScheduleResult.to_csv(path)` to persist the calculated schedule directly to disk. The generated CSV lists each task with its earliest/latest start and finish timestamps, total float, and critical-path flag so the data can be analysed in other tools.

--- a/cps_tool/cli.py
+++ b/cps_tool/cli.py
@@ -2,10 +2,9 @@
 from __future__ import annotations
 
 import argparse
-import csv
 from datetime import datetime, time
 from pathlib import Path
-from typing import Iterable, Sequence
+from typing import Sequence
 
 from .calendar import WorkCalendar, parse_weekend
 from .calculator import calculate_schedule
@@ -38,17 +37,6 @@ def _parse_datetime(value: str) -> datetime:
     raise argparse.ArgumentTypeError(
         "Datetime values must use ISO-8601 format (YYYY-MM-DD or YYYY-MM-DDTHH:MM[:SS])."
     )
-
-
-def _write_schedule(output_path: Path, rows: Iterable[dict[str, str]]) -> None:
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    rows = list(rows)
-    if not rows:
-        return
-    with output_path.open("w", newline="", encoding="utf-8") as handle:
-        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
-        writer.writeheader()
-        writer.writerows(rows)
 
 
 def _handle_convert(args: argparse.Namespace) -> None:
@@ -105,7 +93,7 @@ def _handle_calculate(args: argparse.Namespace) -> None:
             print(f"    {issue.formatted_issue()}")
     if args.output:
         output_path = Path(args.output)
-        _write_schedule(output_path, result.to_rows())
+        result.to_csv(output_path)
         print(f"  Detailed schedule written to {output_path}")
 
 

--- a/cps_tool/models.py
+++ b/cps_tool/models.py
@@ -1,8 +1,10 @@
 """Core dataclasses used by the CPS tooling package."""
 from __future__ import annotations
 
+import csv
 from dataclasses import dataclass, field
 from datetime import datetime
+from pathlib import Path
 from typing import Iterable, List, Optional
 
 
@@ -129,3 +131,33 @@ class ScheduleResult:
                 }
             )
         return rows
+
+    def to_csv(self, destination: Path | str) -> Path:
+        """Write the calculated schedule to ``destination`` as CSV."""
+
+        rows = self.to_rows()
+        fieldnames = list(rows[0].keys()) if rows else [
+            "uid",
+            "name",
+            "earliest_start",
+            "earliest_finish",
+            "latest_start",
+            "latest_finish",
+            "total_float_hours",
+            "is_critical",
+            "duration_days",
+            "is_milestone",
+            "constraint_type",
+            "constraint_date",
+        ]
+
+        destination_path = Path(destination)
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with destination_path.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fieldnames)
+            writer.writeheader()
+            if rows:
+                writer.writerows(rows)
+
+        return destination_path

--- a/tests/test_schedule_export.py
+++ b/tests/test_schedule_export.py
@@ -1,0 +1,51 @@
+import csv
+import sys
+from datetime import datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from cps_tool.models import ScheduleResult, ScheduledTask, TaskSpec
+
+
+def _example_task(uid: int) -> ScheduledTask:
+    spec = TaskSpec(uid=uid, name=f"Task {uid}", duration_days=1.5)
+    start = datetime(2024, 1, uid, 8, 0)
+    finish = datetime(2024, 1, uid, 17, 0)
+    return ScheduledTask(
+        spec=spec,
+        earliest_start=start,
+        earliest_finish=finish,
+        latest_start=start,
+        latest_finish=finish,
+        total_float_hours=0.0,
+    )
+
+
+def test_schedule_result_to_csv(tmp_path):
+    task = _example_task(2)
+    result = ScheduleResult(
+        project_start=datetime(2024, 1, 2, 8, 0),
+        project_finish=datetime(2024, 1, 2, 17, 0),
+        tasks=[task],
+    )
+
+    output_path = tmp_path / "schedule.csv"
+    written_path = result.to_csv(output_path)
+
+    assert written_path == output_path
+    assert output_path.exists()
+
+    with output_path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        rows = list(reader)
+
+    assert reader.fieldnames is not None
+    assert {"earliest_start", "earliest_finish", "latest_start", "latest_finish"}.issubset(
+        set(reader.fieldnames)
+    )
+    assert len(rows) == 1
+    assert rows[0]["uid"] == "2"
+    assert rows[0]["name"] == "Task 2"


### PR DESCRIPTION
## Summary
- add a `ScheduleResult.to_csv` helper to write calculated schedules to CSV
- update the CLI calculate command and README to highlight the new export workflow
- cover the helper with a regression test that ensures start/finish columns are written

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dda7e12a60832597be6582ceac3d8b