### PR TITLE
Add helper script to export calculated schedules to XLSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,15 @@ if result.cycle_resolutions:
 The `ScheduleResult.to_rows()` helper returns dictionaries that can be written back to CSV (the CLI uses the same method). The calculator honours Finish-to-Start, Start-to-Start, Finish-to-Finish, and Start-to-Finish dependencies, plus common constraint types such as “Must Start On” and “Finish No Earlier Than”.
 
 Call `ScheduleResult.to_csv(path)` to persist the calculated schedule directly to disk. The generated CSV lists each task with its earliest/latest start and finish timestamps, total float, and critical-path flag so the data can be analysed in other tools.
+
+### 7.4. Exporting the schedule to XLSX
+
+The repository includes a helper script that mirrors the `cps_rules_level_4.xlsx` workbook layout while augmenting it with calculated dates. Provide the same CSV you would pass to `cps_tool.cli calculate` and specify an output path for the workbook:
+
+```bash
+python scripts/calculate_schedule.py outputs/generic_cps_sample.csv \
+  --project-start 2023-01-02T08:00 \
+  --output outputs/generic_cps_schedule.xlsx
+```
+
+The generated sheet preserves key metadata columns—such as responsible teams and approval requirements when they are present in the source CSV—and adds earliest/latest start and finish dates, task float, and critical-path flags for each activity.

--- a/cps_tool/xlsx.py
+++ b/cps_tool/xlsx.py
@@ -1,0 +1,198 @@
+"""Minimal XLSX writer tailored for CPS schedule exports."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Sequence
+from xml.sax.saxutils import escape
+import zipfile
+
+
+def _column_letter(index: int) -> str:
+    """Return the Excel column letter for a zero-based column index."""
+
+    if index < 0:
+        raise ValueError("Column index must be non-negative")
+    result = []
+    while True:
+        index, remainder = divmod(index, 26)
+        result.append(chr(ord("A") + remainder))
+        if index == 0:
+            break
+        index -= 1
+    return "".join(reversed(result))
+
+
+def _stringify(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, datetime):
+        return value.isoformat(sep=" ", timespec="minutes")
+    return str(value)
+
+
+def _current_timestamp() -> str:
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    return now.isoformat().replace("+00:00", "Z")
+
+
+def _content_types_xml() -> str:
+    return (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">"
+        "<Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>"
+        "<Default Extension=\"xml\" ContentType=\"application/xml\"/>"
+        "<Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/>"
+        "<Override PartName=\"/xl/worksheets/sheet1.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>"
+        "<Override PartName=\"/xl/styles.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml\"/>"
+        "<Override PartName=\"/docProps/core.xml\" ContentType=\"application/vnd.openxmlformats-package.core-properties+xml\"/>"
+        "<Override PartName=\"/docProps/app.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.extended-properties+xml\"/>"
+        "</Types>"
+    )
+
+
+def _rels_xml() -> str:
+    return (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
+        "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\"/>"
+        "<Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties\" Target=\"docProps/core.xml\"/>"
+        "<Relationship Id=\"rId3\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties\" Target=\"docProps/app.xml\"/>"
+        "</Relationships>"
+    )
+
+
+def _workbook_rels_xml() -> str:
+    return (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
+        "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet1.xml\"/>"
+        "<Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\" Target=\"styles.xml\"/>"
+        "</Relationships>"
+    )
+
+
+def _workbook_xml(sheet_name: str) -> str:
+    escaped = escape(sheet_name)
+    return (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" "
+        "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">"
+        "<sheets><sheet name=\"" + escaped + "\" sheetId=\"1\" r:id=\"rId1\"/></sheets>"
+        "</workbook>"
+    )
+
+
+def _styles_xml() -> str:
+    return (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<styleSheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">"
+        "<fonts count=\"1\"><font><sz val=\"11\"/><color theme=\"1\"/><name val=\"Calibri\"/><family val=\"2\"/></font></fonts>"
+        "<fills count=\"2\"><fill><patternFill patternType=\"none\"/></fill><fill><patternFill patternType=\"gray125\"/></fill></fills>"
+        "<borders count=\"1\"><border><left/><right/><top/><bottom/><diagonal/></border></borders>"
+        "<cellStyleXfs count=\"1\"><xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/></cellStyleXfs>"
+        "<cellXfs count=\"1\"><xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\"/></cellXfs>"
+        "<cellStyles count=\"1\"><cellStyle name=\"Normal\" xfId=\"0\" builtinId=\"0\"/></cellStyles>"
+        "</styleSheet>"
+    )
+
+
+def _core_props_xml(timestamp: str) -> str:
+    return (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<cp:coreProperties xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\" "
+        "xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:dcmitype=\"http://purl.org/dc/dcmitype/\" "
+        "xmlns:dcterms=\"http://purl.org/dc/terms/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">"
+        "<dc:title>CPS Schedule</dc:title>"
+        "<dc:creator>CPS Tooling</dc:creator>"
+        "<cp:lastModifiedBy>CPS Tooling</cp:lastModifiedBy>"
+        "<dcterms:created xsi:type=\"dcterms:W3CDTF\">" + timestamp + "</dcterms:created>"
+        "<dcterms:modified xsi:type=\"dcterms:W3CDTF\">" + timestamp + "</dcterms:modified>"
+        "</cp:coreProperties>"
+    )
+
+
+def _app_props_xml() -> str:
+    return (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<Properties xmlns=\"http://schemas.openxmlformats.org/officeDocument/2006/extended-properties\" "
+        "xmlns:vt=\"http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes\">"
+        "<Application>Python</Application>"
+        "</Properties>"
+    )
+
+
+def _sheet_xml(headers: Sequence[str], rows: Iterable[Sequence[object]]) -> str:
+    all_rows: list[list[str]] = [[_stringify(value) for value in headers]]
+    for row in rows:
+        all_rows.append([_stringify(value) for value in row])
+
+    if not all_rows:
+        return (
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">"
+            "<sheetData/>"
+            "</worksheet>"
+        )
+
+    max_columns = max(len(row) for row in all_rows)
+    max_rows = len(all_rows)
+
+    if max_columns == 0:
+        dimension = "A1:A1"
+    else:
+        last_column = _column_letter(max_columns - 1)
+        dimension = f"A1:{last_column}{max_rows}"
+
+    rows_xml: list[str] = []
+    for row_index, row in enumerate(all_rows, start=1):
+        cells: list[str] = []
+        for column_index in range(max_columns):
+            value = row[column_index] if column_index < len(row) else ""
+            if value == "":
+                continue
+            column_letter = _column_letter(column_index)
+            cell_reference = f"{column_letter}{row_index}"
+            cells.append(
+                "<c r=\""
+                + cell_reference
+                + "\" t=\"inlineStr\"><is><t>"
+                + escape(value)
+                + "</t></is></c>"
+            )
+        rows_xml.append("<row r=\"" + str(row_index) + "\">" + "".join(cells) + "</row>")
+
+    sheet_data = "".join(rows_xml)
+    return (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">"
+        "<dimension ref=\"" + dimension + "\"/>"
+        "<sheetData>" + sheet_data + "</sheetData>"
+        "</worksheet>"
+    )
+
+
+def write_xlsx(
+    destination: str | Path,
+    headers: Sequence[str],
+    rows: Iterable[Sequence[object]],
+    sheet_name: str = "Schedule",
+) -> Path:
+    """Write a simple XLSX workbook containing ``headers`` and ``rows``."""
+
+    destination_path = Path(destination)
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+
+    timestamp = _current_timestamp()
+    with zipfile.ZipFile(destination_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("[Content_Types].xml", _content_types_xml())
+        zf.writestr("_rels/.rels", _rels_xml())
+        zf.writestr("docProps/core.xml", _core_props_xml(timestamp))
+        zf.writestr("docProps/app.xml", _app_props_xml())
+        zf.writestr("xl/_rels/workbook.xml.rels", _workbook_rels_xml())
+        zf.writestr("xl/workbook.xml", _workbook_xml(sheet_name))
+        zf.writestr("xl/styles.xml", _styles_xml())
+        zf.writestr("xl/worksheets/sheet1.xml", _sheet_xml(headers, rows))
+
+    return destination_path
+

--- a/scripts/calculate_schedule.py
+++ b/scripts/calculate_schedule.py
@@ -1,0 +1,283 @@
+"""Run the CPS calculator and export the schedule as an XLSX workbook."""
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from datetime import datetime, time
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from cps_tool.calendar import WorkCalendar, parse_weekend
+from cps_tool.calculator import calculate_schedule
+from cps_tool.csv_loader import load_tasks_from_csv
+from cps_tool.models import ScheduledTask
+from cps_tool.xlsx import write_xlsx
+
+
+BASE_HEADERS = [
+    "TaskId",
+    "Responsible Sub-team",
+    "Responsible Function",
+    "Approval Needed",
+    "Rtask Name",
+    "Task Level",
+    "Predecessors IDs",
+    "Successors IDs",
+    "SCOPE",
+    "Base Duration",
+]
+
+SCHEDULE_HEADERS = [
+    "Duration (days)",
+    "Earliest Start",
+    "Earliest Finish",
+    "Latest Start",
+    "Latest Finish",
+    "Total Float (hours)",
+    "Is Critical",
+    "Constraint Type",
+    "Constraint Date",
+    "Original Start",
+    "Original Finish",
+]
+
+
+DATETIME_PATTERNS = ["%Y-%m-%d", "%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S"]
+
+
+def _parse_time(value: str) -> time:
+    try:
+        return datetime.strptime(value, "%H:%M").time()
+    except ValueError as exc:  # pragma: no cover - defensive parsing
+        msg = "Time values must use HH:MM format."
+        raise argparse.ArgumentTypeError(msg) from exc
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        pass
+    for pattern in DATETIME_PATTERNS:
+        try:
+            return datetime.strptime(value, pattern)
+        except ValueError:
+            continue
+    raise argparse.ArgumentTypeError(
+        "Datetime values must use ISO-8601 format (YYYY-MM-DD or YYYY-MM-DDTHH:MM[:SS])."
+    )
+
+
+def _read_metadata(csv_path: Path) -> Dict[str, Dict[str, str]]:
+    metadata: Dict[str, Dict[str, str]] = {}
+    if not csv_path.exists():
+        return metadata
+    with csv_path.open("r", newline="", encoding="utf-8-sig") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            uid_raw = (
+                row.get("TaskId")
+                or row.get("Task ID")
+                or row.get("uid")
+                or row.get("UID")
+                or row.get("Unique ID")
+            )
+            if not uid_raw:
+                continue
+            uid_text = str(uid_raw).strip()
+            if not uid_text:
+                continue
+            try:
+                uid_key = str(int(float(uid_text)))
+            except ValueError:
+                uid_key = uid_text
+            metadata[uid_key] = {key: value for key, value in row.items()}
+    return metadata
+
+
+def _format_datetime(dt: datetime | None) -> str:
+    if dt is None:
+        return ""
+    return dt.strftime("%Y-%m-%d %H:%M")
+
+
+def _metadata_lookup(row: Dict[str, str] | None, *keys: str, default: str = "") -> str:
+    if not row:
+        return default
+    for key in keys:
+        if key in row and row[key]:
+            return str(row[key])
+    return default
+
+
+def _build_successors(tasks: Sequence[ScheduledTask]) -> Dict[int, List[int]]:
+    mapping: Dict[int, List[int]] = {task.spec.uid: [] for task in tasks}
+    for task in tasks:
+        for dependency in task.spec.dependencies:
+            mapping.setdefault(dependency.predecessor_uid, []).append(task.spec.uid)
+    for successors in mapping.values():
+        successors.sort()
+    return mapping
+
+
+def _compose_rows(
+    tasks: Sequence[ScheduledTask],
+    metadata: Dict[str, Dict[str, str]],
+) -> Iterable[List[str]]:
+    successors = _build_successors(tasks)
+    for task in tasks:
+        uid_text = str(task.spec.uid)
+        row_meta = metadata.get(uid_text)
+
+        predecessors_override = _metadata_lookup(
+            row_meta,
+            "Predecessors IDs",
+            "Predecessor IDs",
+            "Predecessors",
+        )
+        if predecessors_override:
+            predecessors_display = predecessors_override
+        else:
+            predecessors_display = ",".join(
+                str(dep.predecessor_uid) for dep in task.spec.dependencies
+            )
+
+        successors_override = _metadata_lookup(
+            row_meta, "Successors IDs", "Successor IDs", "Successors"
+        )
+        if successors_override:
+            successors_display = successors_override
+        else:
+            successors_display = ",".join(
+                str(uid) for uid in successors.get(task.spec.uid, [])
+            )
+
+        base_duration = _metadata_lookup(
+            row_meta,
+            "Base Duration",
+            "Calculated Duration (days)",
+            "Duration",
+            "duration_days",
+        )
+        if not base_duration:
+            base_duration = f"{task.spec.duration_days:g}d"
+
+        outline = _metadata_lookup(row_meta, "Task Level", "Level", default="")
+        if not outline and task.spec.outline_level is not None:
+            outline = f"L{task.spec.outline_level}"
+
+        yield [
+            _metadata_lookup(row_meta, "TaskId", "Task ID", "uid", "UID", default=uid_text),
+            _metadata_lookup(row_meta, "Responsible Sub-team", "Sub-team"),
+            _metadata_lookup(row_meta, "Responsible Function", "Function"),
+            _metadata_lookup(row_meta, "Approval Needed"),
+            _metadata_lookup(row_meta, "Rtask Name", "Task Name", "name", default=task.spec.name),
+            outline,
+            predecessors_display,
+            successors_display,
+            _metadata_lookup(row_meta, "SCOPE", "Scope"),
+            base_duration,
+            f"{task.spec.duration_days:.3f}",
+            _format_datetime(task.earliest_start),
+            _format_datetime(task.earliest_finish),
+            _format_datetime(task.latest_start),
+            _format_datetime(task.latest_finish),
+            f"{task.total_float_hours:.2f}",
+            "YES" if task.is_critical else "NO",
+            task.spec.constraint_type or "",
+            _format_datetime(task.spec.constraint_date),
+            _metadata_lookup(
+                row_meta,
+                "Original Start",
+                "Start",
+                "start",
+                "Planned Start",
+            ),
+            _metadata_lookup(
+                row_meta,
+                "Original Finish",
+                "Finish",
+                "finish",
+                "Planned Finish",
+            ),
+        ]
+
+
+def run_calculation(args: argparse.Namespace) -> Path:
+    csv_path = Path(args.csv_path)
+    metadata = _read_metadata(csv_path)
+
+    tasks = load_tasks_from_csv(csv_path)
+    weekend = parse_weekend(args.weekend or [])
+    calendar = WorkCalendar(
+        workday_start=_parse_time(args.workday_start),
+        workday_end=_parse_time(args.workday_end),
+        weekend_days=weekend,
+    )
+    project_start = _parse_datetime(args.project_start)
+
+    result = calculate_schedule(tasks, project_start=project_start, calendar=calendar)
+
+    headers = BASE_HEADERS + SCHEDULE_HEADERS
+    rows = list(_compose_rows(result.tasks, metadata))
+    sheet_name = args.sheet_name or "Schedule"
+    return write_xlsx(args.output, headers, rows, sheet_name=sheet_name)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Calculate a CPS schedule and export it as an XLSX workbook."
+    )
+    parser.add_argument("csv_path", type=Path, help="Path to the source task CSV file")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Destination XLSX path",
+    )
+    parser.add_argument(
+        "--sheet-name",
+        dest="sheet_name",
+        help="Optional sheet name for the workbook",
+    )
+    parser.add_argument(
+        "--project-start",
+        dest="project_start",
+        help="Override project start (ISO-8601 datetime)",
+    )
+    parser.add_argument(
+        "--workday-start",
+        default="08:00",
+        help="Start of the workday (HH:MM)",
+    )
+    parser.add_argument(
+        "--workday-end",
+        default="17:00",
+        help="End of the workday (HH:MM)",
+    )
+    parser.add_argument(
+        "--weekend",
+        nargs="*",
+        default=None,
+        help="Weekend days, e.g. 'sat sun' or '5 6'",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    output_path = run_calculation(args)
+    print(f"Schedule written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add a minimal XLSX writer to the CPS tooling package
- add a calculate_schedule script that emits a workbook matching the cps_rules_level_4.xlsx structure while including schedule dates
- document how to export the schedule to XLSX in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddaf3b15688325bb6c12a44f30b123