### PR TITLE
Enable downloading preprocessed Excel workbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An interactive, browser-based tool for validating complex critical path schedule
 - **Interactive dependency graph** – Visualize predecessor/successor relationships, auto-include nearby context, and highlight task metadata.
 - **Dependency typing** – Add a `Dependency Type` column (FS/SS/SF/FF) to distinguish relationships; otherwise Finish-to-Start (FS) is assumed.
 - **Stakeholder-friendly UI** – Styled for projection or screen sharing; no coding experience required.
+- **Download cleaned workbook** – Retrieve the Excel file produced by the preprocessing service for archival or further review.
 
 A lightweight sample dataset is included in [`webapp/data/sample_schedule.json`](webapp/data/sample_schedule.json) and the repository ships with the stakeholder workbook `CPS_Rules_comm_LPA_Readiness.xlsx` for real-world testing.
 


### PR DESCRIPTION
## Summary
- add preprocessing helper to serialize cleaned workbooks as Excel bytes
- expose the Excel payload through the preprocessing API and surface it in the UI download flow
- document the new download capability in the README

## Testing
- python -m compileall server.py cps_preprocessor.py webapp/app.js
- python - <<'PY'
from cps_preprocessor import preprocess_excel_with_workbook
from pathlib import Path

path = Path('CPS_Rules_comm_LPA_Readiness.xlsx')
with path.open('rb') as fh:
    result = preprocess_excel_with_workbook(fh.read())

print('rows', len(result.rows))
print('metadata', result.metadata)
print('excel-bytes', len(result.excel_bytes))
PY

------
https://chatgpt.com/codex/tasks/task_e_68ddf051c23883258e4f4dfbbd86329d