### PR TITLE
Add experience selection tabs to align with README instructions

### DIFF
--- a/webapp/dag.html
+++ b/webapp/dag.html
@@ -21,6 +21,12 @@
           interdependencies, and surface scope mismatches across teams.
         </p>
       </div>
+      <nav class="experience-tabs" aria-label="Choose your experience">
+        <a class="experience-tab" href="index.html">Schedule explorer</a>
+        <a class="experience-tab current" href="dag.html" aria-current="page">
+          Task dependency explorer
+        </a>
+      </nav>
       <div class="actions">
         <a class="secondary-button" href="index.html">Back to schedule view</a>
         <a class="secondary-button" href="data/amy_new_cps_tasks.json" download>

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -24,6 +24,12 @@
           and validate the plan with your stakeholders.
         </p>
       </div>
+      <nav class="experience-tabs" aria-label="Choose your experience">
+        <a class="experience-tab current" href="index.html" aria-current="page">
+          Schedule explorer
+        </a>
+        <a class="experience-tab" href="dag.html">Task dependency explorer</a>
+      </nav>
       <div class="actions">
         <label class="file-input">
           <span>Upload Excel (.xlsx)</span>

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -63,6 +63,41 @@ body {
   background: rgba(15, 23, 42, 0.85);
   color: var(--text-light);
   gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.experience-tabs {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0.35rem;
+  border-radius: 999px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.experience-tab {
+  color: var(--text-light);
+  text-decoration: none;
+  font-weight: 600;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+}
+
+.experience-tab:hover,
+.experience-tab:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.experience-tab.current {
+  background: white;
+  color: var(--accent);
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.25);
 }
 
 .app-header h1 {


### PR DESCRIPTION
## Summary
- add an experience selector nav to the schedule view so users can reach both entry points
- mirror the selector on the DAG view with the correct active state
- style the tabs to fit within the existing header design and wrap on smaller screens

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e5b3721d0c8325a46a80fcd0a800f6