### PR TITLE
Support uploads for the task dependency explorer

### DIFF
--- a/cps_preprocessor.py
+++ b/cps_preprocessor.py
@@ -12,7 +12,10 @@ from xml.etree import ElementTree as ET
 from xml.sax.saxutils import escape
 from zipfile import ZIP_DEFLATED, ZipFile
 
-import pandas as pd
+try:
+    import pandas as pd
+except ImportError:  # pragma: no cover - pandas is optional for most workflows
+    pd = None  # type: ignore[assignment]
 
 
 @dataclass
@@ -77,8 +80,13 @@ def preprocess_excel(data: bytes) -> Tuple[List[Dict[str, str]], Dict[str, int |
     return result.rows, result.metadata
 
 
-def preprocess_excel_to_dataframe(data: bytes) -> pd.DataFrame:
+def preprocess_excel_to_dataframe(data: bytes) -> "pd.DataFrame":
     """Return the cleaned workbook rows as a :class:`pandas.DataFrame`."""
+
+    if pd is None:  # pragma: no cover - exercised only when pandas is available
+        raise ImportError(
+            "pandas is required to export the cleaned workbook as a DataFrame."
+        )
 
     result = preprocess_excel_with_workbook(data)
     return _result_to_dataframe(result)
@@ -656,8 +664,13 @@ def _column_letter(index: int) -> str:
     return "".join(reversed(letters))
 
 
-def _result_to_dataframe(result: PreprocessResult) -> pd.DataFrame:
+def _result_to_dataframe(result: PreprocessResult) -> "pd.DataFrame":
     """Convert a :class:`PreprocessResult` into a :class:`pandas.DataFrame`."""
+
+    if pd is None:  # pragma: no cover - exercised only when pandas is available
+        raise ImportError(
+            "pandas is required to export the cleaned workbook as a DataFrame."
+        )
 
     dataframe = pd.DataFrame(result.rows)
     if result.workbook.headers:

--- a/dag_loader.py
+++ b/dag_loader.py
@@ -1,0 +1,46 @@
+"""Utilities for parsing task dependency workbooks used by the DAG explorer."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+from cps_preprocessor import _read_workbook, _stringify, WorkbookData
+
+
+@dataclass
+class TaskDependencyPayload:
+    """Normalized representation of the dependency workbook."""
+
+    records: List[Dict[str, str]]
+    headers: Tuple[str, ...]
+
+
+def load_task_dependency_records(data: bytes) -> TaskDependencyPayload:
+    """Load and normalize rows from a CPS task dependency workbook.
+
+    The explorer expects string values with leading/trailing whitespace trimmed.  The
+    workbook headers are preserved in their original order so clients can re-create a
+    tabular view when needed.
+    """
+
+    workbook = _read_workbook(data)
+    records = _normalize_rows(workbook)
+    headers = tuple(workbook.headers)
+    return TaskDependencyPayload(records=records, headers=headers)
+
+
+def _normalize_rows(workbook: WorkbookData) -> List[Dict[str, str]]:
+    normalized: List[Dict[str, str]] = []
+    headers = list(workbook.headers)
+    for row in workbook.rows:
+        record: Dict[str, str] = {}
+        for header in headers:
+            record[header] = _normalize_value(row.get(header, ""))
+        if any(value for value in record.values()):
+            normalized.append(record)
+    return normalized
+
+
+def _normalize_value(value: object) -> str:
+    text = _stringify(value)
+    return text.strip()

--- a/tests/dag-data.test.mjs
+++ b/tests/dag-data.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { buildTaskIndex, normalizeRecords, parseLinkedIds } from '../webapp/dag-data.js';
+
+const datasetUrl = new URL('../webapp/data/amy_new_cps_tasks.json', import.meta.url);
+const dataset = JSON.parse(readFileSync(fileURLToPath(datasetUrl), 'utf8'));
+
+const normalizedDataset = normalizeRecords(dataset);
+
+test('normalizeRecords trims whitespace and preserves fields', () => {
+  const sample = normalizeRecords([{ 'Task Name': ' Example ', TaskID: ' 42 ' }]);
+  assert.equal(sample[0]['Task Name'], 'Example');
+  assert.equal(sample[0].TaskID, '42');
+});
+
+test('buildTaskIndex creates lookup map with expected tasks', () => {
+  const { tasks, tasksById } = buildTaskIndex(normalizedDataset);
+  assert.equal(tasks.length, normalizedDataset.length);
+
+  const task = tasksById.get('18');
+  assert(task);
+  assert.equal(task.name, 'XX Country Sales Samples Due to "Company Issuing Sales Samples to Trade" (date needed)');
+  assert.deepEqual(task.predecessors, ['1004']);
+  assert.deepEqual(task.successors, ['21']);
+  assert.equal(task.phase, 'Launch');
+});
+
+test('parseLinkedIds extracts identifiers regardless of separators', () => {
+  assert.deepEqual(parseLinkedIds('1004, 1005'), ['1004', '1005']);
+  assert.deepEqual(parseLinkedIds('ABC-123 SS; XYZ-789'), ['ABC-123', 'XYZ-789']);
+  assert.deepEqual(parseLinkedIds(''), []);
+});

--- a/tests/test_dag_upload.py
+++ b/tests/test_dag_upload.py
@@ -1,0 +1,72 @@
+import json
+import threading
+import unittest
+from functools import partial
+from http.client import HTTPConnection
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+from dag_loader import load_task_dependency_records
+from server import CPSRequestHandler, WEBAPP_DIR
+
+
+def _load_workbook_bytes() -> bytes:
+    return Path("amy_cps_new_only_tasks.xlsx").read_bytes()
+
+
+class TaskDependencyUploadTests(unittest.TestCase):
+    def test_load_task_dependency_records(self) -> None:
+        payload = load_task_dependency_records(_load_workbook_bytes())
+        self.assertEqual(payload.headers[0], "TaskID")
+        self.assertEqual(len(payload.records), 916)
+
+        first = payload.records[0]
+        self.assertEqual(first["TaskID"], "18")
+        self.assertEqual(first["Predecessors"], "1004")
+        self.assertEqual(first["Successors"], "21")
+        self.assertEqual(first["Current SIMPL Phase (visibility)"], "Launch")
+        # Ensure whitespace is trimmed from text fields.
+        self.assertTrue(first["Task Name"].endswith("(date needed)"))
+
+    def test_dag_upload_endpoint(self) -> None:
+        handler = partial(CPSRequestHandler, directory=str(WEBAPP_DIR))
+        server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+        try:
+            host, port = server.server_address
+            boundary = "----PyTestBoundary0X"
+            body_prefix = (
+                f"--{boundary}\r\n"
+                'Content-Disposition: form-data; name="file"; filename="amy_cps_new_only_tasks.xlsx"\r\n'
+                "Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet\r\n\r\n"
+            ).encode("utf-8")
+            body_suffix = f"\r\n--{boundary}--\r\n".encode("utf-8")
+            body = body_prefix + _load_workbook_bytes() + body_suffix
+
+            headers = {
+                "Content-Type": f"multipart/form-data; boundary={boundary}",
+                "Content-Length": str(len(body)),
+            }
+
+            connection = HTTPConnection(host, port)
+            connection.request("POST", "/api/dag/upload", body=body, headers=headers)
+            response = connection.getresponse()
+            data = response.read()
+            connection.close()
+
+            self.assertEqual(response.status, 200, data)
+
+            payload = json.loads(data.decode("utf-8"))
+            self.assertIn("records", payload)
+            self.assertEqual(len(payload["records"]), 916)
+            self.assertEqual(payload["records"][0]["TaskID"], "18")
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webapp/dag-data.js
+++ b/webapp/dag-data.js
@@ -1,0 +1,102 @@
+export function normalizeRecords(records) {
+  if (!Array.isArray(records)) {
+    return [];
+  }
+
+  return records
+    .map((record) => normalizeRecord(record))
+    .filter((record) => record !== null);
+}
+
+function normalizeRecord(record) {
+  if (!record || typeof record !== "object") {
+    return null;
+  }
+
+  const normalized = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (typeof value === "string") {
+      normalized[key] = value.trim();
+    } else if (value == null) {
+      normalized[key] = "";
+    } else {
+      normalized[key] = String(value);
+    }
+  }
+  return normalized;
+}
+
+export function buildTaskIndex(records) {
+  const tasks = [];
+  const tasksById = new Map();
+
+  for (const record of records) {
+    const id = resolveTaskId(record);
+    if (!id) {
+      continue;
+    }
+
+    const task = {
+      id,
+      name: record["Task Name"] || record["Task"] || "Untitled task",
+      phase:
+        record["Current SIMPL Phase (visibility)"] ||
+        record["Current SIMPL Phase"] ||
+        "",
+      lego:
+        record["Commercial/Technical Lego Block"] ||
+        record["Commercial Lego Block"] ||
+        record["Technical Lego Block"] ||
+        "",
+      scope: record["Scope Definition (Arnab)"] || record["Scope"] || "",
+      predecessors: parseLinkedIds(
+        record.Predecessors || record["Predecessors IDs"] || "",
+      ),
+      successors: parseLinkedIds(
+        record.Successors || record["Successors IDs"] || "",
+      ),
+      raw: record,
+    };
+
+    tasks.push(task);
+    tasksById.set(task.id, task);
+  }
+
+  return { tasks, tasksById };
+}
+
+function resolveTaskId(record) {
+  const candidates = [
+    record.TaskID,
+    record.TaskId,
+    record["Task ID"],
+    record.id,
+    record.ID,
+  ];
+
+  for (const candidate of candidates) {
+    if (candidate == null) {
+      continue;
+    }
+    const text = String(candidate).trim();
+    if (text) {
+      return text;
+    }
+  }
+  return "";
+}
+
+export function parseLinkedIds(value) {
+  if (!value) {
+    return [];
+  }
+  return String(value)
+    .split(/[,\n;]/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => {
+      const match = part.match(/([A-Za-z0-9_.-]+)/);
+      return match ? match[1] : null;
+    })
+    .filter(Boolean);
+}

--- a/webapp/dag.html
+++ b/webapp/dag.html
@@ -13,6 +13,15 @@
     />
   </head>
   <body>
+    <div
+      id="dag-processing-notice"
+      class="processing-notice"
+      role="status"
+      aria-live="polite"
+      hidden
+    >
+      Processing task dependency workbook…
+    </div>
     <header class="app-header">
       <div>
         <h1>CPS Task Dependency Explorer</h1>
@@ -28,10 +37,15 @@
         </a>
       </nav>
       <div class="actions">
-        <a class="secondary-button" href="index.html">Back to schedule view</a>
-        <a class="secondary-button" href="data/amy_new_cps_tasks.json" download>
-          Download source data
+        <label class="file-input">
+          <span>Upload Excel (.xlsx)</span>
+          <input id="dag-file-input" type="file" accept=".xlsx,.xls" />
+        </label>
+        <button id="dag-load-default" type="button">Reload default data</button>
+        <a id="dag-download-json" class="secondary-button" download>
+          Download current data
         </a>
+        <a class="secondary-button" href="index.html">Back to schedule view</a>
       </div>
     </header>
 

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -146,6 +146,11 @@ button {
   box-shadow: 0 2px 12px rgba(37, 99, 235, 0.25);
 }
 
+.actions .secondary-button.disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
 button:hover,
 .file-input:hover span {
   transform: translateY(-1px);


### PR DESCRIPTION
## Summary
- add a lightweight loader for CPS task dependency workbooks and expose it via `/api/dag/upload`
- enhance the task dependency explorer UI to accept workbook uploads, reload the default dataset, and download the current JSON
- add shared data helpers and automated tests covering the upload service and front-end record parsing

## Testing
- python -m unittest discover tests
- node --test tests/dag-data.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e5b5b496b88325a208fae7a3c0435e