### PR TITLE
Fix DAG overlay message and normalize scope casing

### DIFF
--- a/webapp/dag-data.js
+++ b/webapp/dag-data.js
@@ -23,6 +23,17 @@ function normalizeRecord(record) {
       normalized[key] = String(value);
     }
   }
+
+  if ("Scope Definition (Arnab)" in normalized) {
+    normalized["Scope Definition (Arnab)"] = normalizeScope(
+      normalized["Scope Definition (Arnab)"],
+    );
+  }
+
+  if ("Scope" in normalized) {
+    normalized["Scope"] = normalizeScope(normalized["Scope"]);
+  }
+
   return normalized;
 }
 
@@ -48,7 +59,7 @@ export function buildTaskIndex(records) {
         record["Commercial Lego Block"] ||
         record["Technical Lego Block"] ||
         "",
-      scope: record["Scope Definition (Arnab)"] || record["Scope"] || "",
+      scope: normalizeScope(record["Scope Definition (Arnab)"] || record["Scope"] || ""),
       lp: record.LP || "",
       predecessors: parseLinkedIds(
         record.Predecessors || record["Predecessors IDs"] || "",
@@ -85,6 +96,19 @@ function resolveTaskId(record) {
     }
   }
   return "";
+}
+
+function normalizeScope(value) {
+  if (value == null) {
+    return "";
+  }
+
+  const text = String(value).trim();
+  if (!text) {
+    return "";
+  }
+
+  return text.toUpperCase();
 }
 
 export function parseLinkedIds(value) {

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -644,6 +644,10 @@ button:disabled:hover {
   text-align: center;
 }
 
+.graph-empty[hidden] {
+  display: none !important;
+}
+
 .task-details-list {
   display: grid;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary
- ensure the empty-state overlay hides when the dependency graph is rendered
- normalize all scope definition values to uppercase so filters treat case-insensitive variants as the same scope

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5c0af7da08325a8bc51d74bf928e2