### PR TITLE
Improve readability of focus node labels

### DIFF
--- a/webapp/dag.js
+++ b/webapp/dag.js
@@ -50,7 +50,7 @@ let downloadUrl = null;
 let downloadFilename = "cps_tasks.json";
 let zoomStyleUpdateScheduled = false;
 
-const FOCUS_TEXT_OUTLINE_COLOR = "rgba(248, 250, 252, 0.92)";
+const FOCUS_TEXT_OUTLINE_COLOR = "rgba(15, 23, 42, 0.82)";
 
 const ZOOM_STYLE_DEFAULTS = {
   baseFontSize: 12,


### PR DESCRIPTION
## Summary
- darken the text outline color for focus nodes so white labels remain legible on blue backgrounds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e71f60ca38832596e488db5ed2fdc9